### PR TITLE
Remove `zwindows` dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,29 +8,9 @@ pub fn build(b: *std.Build) !void {
         try checkGitLfsContent();
     };
 
-    const zopenvr = b.addModule("root", .{
+    _ = b.addModule("root", .{
         .root_source_file = b.path("src/openvr.zig"),
     });
-
-    if (b.lazyDependency("zwindows", .{
-        .zxaudio2_debug_layer = b.option(
-            bool,
-            "zxaudio2_debug_layer",
-            "Enable XAudio2 debug layer",
-        ) orelse false,
-        .zd3d12_debug_layer = b.option(
-            bool,
-            "zd3d12_debug_layer",
-            "Enable DirectX 12 debug layer",
-        ) orelse false,
-        .zd3d12_gbv = b.option(
-            bool,
-            "zd3d12_gbv",
-            "Enable DirectX 12 GPU-Based Validation (GBV)",
-        ) orelse false,
-    })) |zwindows| {
-        zopenvr.addImport("zwindows", zwindows.module("zwindows"));
-    }
 }
 
 pub fn addLibraryPathsTo(zopenvr: *std.Build.Dependency, compile_step: *std.Build.Step.Compile) void {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,11 +11,5 @@
         "README.md",
         "LICENSE",
     },
-    .dependencies = .{
-        .zwindows = .{
-            .url = "https://github.com/zig-gamedev/zwindows/archive/c29e0fec072c282a8c6234c5837db071af42a11f.tar.gz",
-            .hash = "zwindows-0.2.0-dev-xMZ1uyZpyQZsF6AeAjn_SJM69htI2MKkskHJ-83XzISl",
-            .lazy = true,
-        },
-    },
+    .dependencies = .{},
 }

--- a/src/common.zig
+++ b/src/common.zig
@@ -1,8 +1,5 @@
 const std = @import("std");
 
-const zwindows = @import("zwindows");
-const d3d12 = zwindows.d3d12;
-
 const root = @This();
 
 pub const InitError = error{
@@ -1105,9 +1102,12 @@ pub const ColorSpace = enum(i32) {
     linear = 2,
 };
 pub const D3D12TextureData = extern struct {
-    resource: *d3d12.IResource,
-    command_queue: *d3d12.ICommandQueue,
+    resource: *ID3D12Resource,
+    command_queue: *ID3D12CommandQueue,
     node_mask: u32,
+
+    pub const ID3D12Resource = opaque {};
+    pub const ID3D12CommandQueue = opaque {};
 };
 pub const Texture = extern struct {
     handle: *const anyopaque,


### PR DESCRIPTION
The `zwindows` dependency was only used to access 2 DirectX types for an optional part of the OpenVR API, and is fetched unconditionally even though it's marked as lazy. This is unnecessary, especially since the C headers just forward declare these types. D3D12 users can `@ptrCast` instead.
